### PR TITLE
Add standard CMake way of running the tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ cmake_minimum_required(VERSION 2.8.4)
 
 project( zipios_project )
 
+enable_testing()
+
 set( ZIPIOS_VERSION_MAJOR 2 )
 set( ZIPIOS_VERSION_MINOR 1 )
 set( ZIPIOS_VERSION_PATCH 1 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,8 @@ add_custom_target(run_zipios_tests
     COMMAND ./zipios_tests
 )
 
+add_test(zipios_tests ${PROJECT_NAME})
+
 else(CATCH_FOUND)
 
 message("No test will be created because you do not seem to have catch.hpp installed...")


### PR DESCRIPTION
Add "make test" using the standard CMake mechanism to augment "make run_zipios_tests" or simply running tests/zipios_tests. 