### PR TITLE
Add an include of the memory header file.

### DIFF
--- a/tests/tests.hpp
+++ b/tests/tests.hpp
@@ -34,6 +34,7 @@
 
 #include <catch.hpp>
 
+#include <memory>
 #include <sstream>
 
 #include <limits.h>


### PR DESCRIPTION
Using g++ 7.0.1 highlights that one file that should have included the memory header file did not.