### PR TITLE
Fix misc. source comment and doxygen typos

### DIFF
--- a/src/collectioncollection.cpp
+++ b/src/collectioncollection.cpp
@@ -42,7 +42,7 @@ namespace
 
 /** \brief Search for an entry.
  *
- * This function searchs for an entry that match the given name.
+ * This function searches for an entry that match the given name.
  * If that entry exists, the \p it parameter will be pointing
  * to it.
  *
@@ -329,7 +329,7 @@ FileEntry::vector_t CollectionCollection::entries() const
  * The collection must be valid or the function raises an exception.
  *
  * \param[in] name  A string containing the name of the entry to get.
- * \param[in] matchpath  Speficy MatchPath::MATCH, if the path should match
+ * \param[in] matchpath  Specify MatchPath::MATCH, if the path should match
  *                       as well, specify MatchPath::IGNORE, if the path
  *                       should be ignored.
  *

--- a/src/directorycollection.cpp
+++ b/src/directorycollection.cpp
@@ -160,7 +160,7 @@ FileEntry::vector_t DirectoryCollection::entries() const
  * The collection must be valid or the function raises an exception.
  *
  * \param[in] name  A string containing the name of the entry to get.
- * \param[in] matchpath  Speficy MatchPath::MATCH, if the path should match
+ * \param[in] matchpath  Specify MatchPath::MATCH, if the path should match
  *                       as well, specify MatchPath::IGNORE, if the path
  *                       should be ignored.
  *

--- a/src/directoryentry.cpp
+++ b/src/directoryentry.cpp
@@ -41,7 +41,7 @@ namespace zipios
  *
  * DirectoryEntry is a FileEntry that is suitable as a base class for
  * basic entries, that do not support any form of compression and
- * in most cases represent a file in a directtory.
+ * in most cases represent a file in a directory.
  */
 
 

--- a/src/dosdatetime.cpp
+++ b/src/dosdatetime.cpp
@@ -126,7 +126,7 @@ int const g_ydays[12] = {
  * Remember that Zip file Date & Time are saved in an old MS-DOS format
  * which did not respect UTC. It instead represents local time. This
  * function returns true when the local time is valid, since the same
- * time will be shared around the globe, it will alway sbe considered
+ * time will be shared around the globe, it will always be considered
  * valid, but the Unix timestamp can look like a mismatch (the minimum
  * and maximum possible time stamps represented in a Unix time_t variable
  * will vary depending on your timezone settings.)

--- a/src/filecollection.cpp
+++ b/src/filecollection.cpp
@@ -412,7 +412,7 @@ FileEntry::vector_t FileCollection::entries() const
  * The collection must be valid or the function raises an exception.
  *
  * \param[in] name  A string containing the name of the entry to get.
- * \param[in] matchpath  Speficy MatchPath::MATCH, if the path should match
+ * \param[in] matchpath  Specify MatchPath::MATCH, if the path should match
  *                       as well, specify MatchPath::IGNORE, if the path
  *                       should be ignored.
  *

--- a/src/fileentry.cpp
+++ b/src/fileentry.cpp
@@ -209,7 +209,7 @@ std::streampos FileEntry::getEntryOffset() const
  * This function returns a copy of the vector of bytes of extra data
  * that are stored with the entry.
  *
- * This buffer should be generated using the still non-existant
+ * This buffer should be generated using the still non-existent
  * ZipExtra class. This includes definitions of additional meta
  * data necessary on various operating systems. For example, Linux
  * makes use of the "UT" (Universal Time) to save the atime, ctime,
@@ -336,7 +336,7 @@ size_t FileEntry::getSize() const
 
 /** \brief Get the MS-DOS date/time of this entry.
  *
- * This function returns the date and time of the entry in MSDOS
+ * This function returns the date and time of the entry in MS-DOS
  * date/time format.
  *
  * \note
@@ -654,7 +654,7 @@ void FileEntry::setSize(size_t size)
  * the setUnixTime() instead since it is one to one compatible with the
  * value handle by time(), stat(), and other OS functions.
  *
- * \param[in] dosdatetime  Set time field as is using this MSDOS date/time value.
+ * \param[in] dosdatetime  Set time field as is using this MS-DOS date/time value.
  */
 void FileEntry::setTime(DOSDateTime::dosdatetime_t dosdatetime)
 {

--- a/src/gzipoutputstream.cpp
+++ b/src/gzipoutputstream.cpp
@@ -72,7 +72,7 @@ GZIPOutputStream::GZIPOutputStream(std::ostream& os, FileEntry::CompressionLevel
 /** \brief Create a named ZIP stream for output.
  *
  * \note
- * The fielname is not automatically saved as part of the stream.
+ * The filename is not automatically saved as part of the stream.
  * To do so, call the setFilename() function.
  *
  * \param[in] filename  Name of the file where the zip archive is to

--- a/src/zipendofcentraldirectory.cpp
+++ b/src/zipendofcentraldirectory.cpp
@@ -20,7 +20,7 @@
 */
 
 /** \file
- * \brief Declare zipios::ZipEndOfCentralDirectory whichs handles entries found
+ * \brief Declare zipios::ZipEndOfCentralDirectory which handles entries found
  *        in a Zip archive directory.
  *
  * This header file contains the zipios::ZipLocalEntry, which is used

--- a/src/zipfile.cpp
+++ b/src/zipfile.cpp
@@ -283,7 +283,7 @@ namespace zipios
 
 
 
-/** \brief Open a zip archive that was previously appened to another file.
+/** \brief Open a zip archive that was previously appended to another file.
  *
  * Opens a Zip archive embedded in another file, by writing the zip
  * archive to the end of the file followed by the start offset of

--- a/src/zipinputstreambuf.cpp
+++ b/src/zipinputstreambuf.cpp
@@ -91,7 +91,7 @@ ZipInputStreambuf::ZipInputStreambuf(std::streambuf *inbuf, offset_t start_pos)
 
 
 /** \fn ZipInputStreambuf::ZipInputStreambuf(ZipInputStreambuf const & src);
- * \brief The copy contructor is deleted.
+ * \brief The copy constructor is deleted.
  *
  * ZipInputStreambuf objects cannot be copied so the copy constructor
  * is deleted.

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -21,7 +21,7 @@
 
 /** \file
  *
- * Zipios unit tests used to verify the various funtions defined in
+ * Zipios unit tests used to verify the various functions defined in
  * zipios_common.hpp.
  */
 
@@ -47,7 +47,7 @@ SCENARIO("Vector append", "[zipios_common]")
 
             es += os;
 
-            THEN("the result is still an emtpy vector")
+            THEN("the result is still an empty vector")
             {
                 REQUIRE(es.empty());
             }

--- a/tests/directoryentry.cpp
+++ b/tests/directoryentry.cpp
@@ -1143,7 +1143,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
             {
                 // DOS time numbers are not linear so we use a Unix date and
-                // convert to DOS time (since we know our convertor works)
+                // convert to DOS time (since we know our converter works)
                 //
                 // Jan 1, 1980 at 00:00:00  is  315561600   (min)
                 // Dec 31, 2107 at 23:59:59  is 4354847999  (max)

--- a/tests/zipfile.cpp
+++ b/tests/zipfile.cpp
@@ -800,7 +800,7 @@ SCENARIO("use Zipios to create zip archives with 1 or 3 files each", "[ZipFile] 
 
 #ifndef __clang__
         // check with a global comment which is too large
-        WHEN("we make sure that saving the file fails if the Zip (gloabl) comment is too large")
+        WHEN("we make sure that saving the file fails if the Zip (global) comment is too large")
         {
             zipios::DirectoryCollection dc("file.bin");
             // generate a random comment of 65Kb

--- a/tools/zipios.cpp
+++ b/tools/zipios.cpp
@@ -40,7 +40,7 @@
 
 /** \brief A few static variables and functions.
  *
- * This namesapce includes various declarations, variables, and funtions
+ * This namesapce includes various declarations, variables, and functions
  * that are specific to the zipios tool, not to be shared with anyone else.
  */
 namespace

--- a/zipios/zipiosexceptions.hpp
+++ b/zipios/zipiosexceptions.hpp
@@ -44,7 +44,7 @@ namespace zipios
 {
 
 
-/** \brief Base exception of the zipios environement
+/** \brief Base exception of the zipios environment
  *
  * Unfortunately, all exceptions are marked as runtime_error.
  *


### PR DESCRIPTION
Found via `codespell -q 3`