### PR TITLE
Fix #38: ZipFile::saveCollectionToArchive creates invalid zip file (bad CRC)

### DIFF
--- a/src/directoryentry.cpp
+++ b/src/directoryentry.cpp
@@ -32,6 +32,8 @@
 
 #include "zipios_common.hpp"
 
+#include <zlib.h>
+#include <fstream>
 
 namespace zipios
 {
@@ -63,6 +65,29 @@ DirectoryEntry::DirectoryEntry(FilePath const & filename, std::string const & co
     {
         m_uncompressed_size = m_filename.isDirectory() ? 0 : m_filename.fileSize();
         m_unix_time = m_filename.lastModificationTime();
+
+        computeCRC32();
+    }
+}
+
+void DirectoryEntry::computeCRC32()
+{
+    if(!m_filename.isDirectory())
+    {
+        std::ifstream fileStream(m_filename);
+        if(fileStream.bad())
+        {
+            throw IOException("Can't open the file.");
+        }
+
+        m_crc_32 = 0;
+        char c = 0;
+        while(fileStream.get(c))
+        {
+            m_crc_32 = crc32(m_crc_32, reinterpret_cast<unsigned char *>(&c), 1);
+        }
+
+        m_has_crc_32 = true;
     }
 }
 

--- a/src/zipoutputstreambuf.cpp
+++ b/src/zipoutputstreambuf.cpp
@@ -366,7 +366,10 @@ void ZipOutputStreambuf::updateEntryHeaderInfo()
     // update fields in m_entries.back()
     FileEntry::pointer_t entry(m_entries.back());
     entry->setSize(getSize());
-    entry->setCrc(getCrc32());
+    if(!entry->hasCrc())
+    {
+        entry->setCrc(getCrc32());
+    }
     /** \TODO
      * Rethink the design as we have to force a call to the correct
      * getHeaderSize() function?

--- a/tests/directorycollection.cpp
+++ b/tests/directorycollection.cpp
@@ -276,7 +276,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -287,16 +286,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -339,7 +341,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -350,16 +351,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -398,7 +402,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -409,16 +412,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -457,7 +463,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -468,16 +473,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -615,7 +623,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -626,16 +633,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -671,7 +681,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -682,16 +691,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -728,7 +740,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -739,16 +750,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");
@@ -785,7 +799,6 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
 
                         REQUIRE((*it)->getComment().empty());
                         REQUIRE((*it)->getCompressedSize() == (*it)->getSize());
-                        REQUIRE((*it)->getCrc() == 0);
                         REQUIRE((*it)->getEntryOffset() == 0);
                         REQUIRE((*it)->getExtra().empty());
                         REQUIRE((*it)->getHeaderSize() == 0);
@@ -796,16 +809,19 @@ TEST_CASE("DirectoryCollection with valid trees of files", "[DirectoryCollection
                         dt.setUnixTimestamp(file_stats.st_mtime);
                         REQUIRE((*it)->getTime() == dt.getDOSDateTime());
                         REQUIRE((*it)->getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE((*it)->hasCrc());
                         if(t == zipios_test::file_t::type_t::DIRECTORY)
                         {
                             REQUIRE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == 0); // size is zero for directories
+                            REQUIRE((*it)->getCrc() == 0);
+                            REQUIRE_FALSE((*it)->hasCrc());
                         }
                         else
                         {
                             REQUIRE_FALSE((*it)->isDirectory());
                             REQUIRE((*it)->getSize() == file_stats.st_size);
+                            REQUIRE((*it)->getCrc() != 0);
+                            REQUIRE((*it)->hasCrc());
                         }
                         REQUIRE((*it)->isValid());
                         //REQUIRE((*it)->toString() == "... (0 bytes)");

--- a/tests/directoryentry.cpp
+++ b/tests/directoryentry.cpp
@@ -773,7 +773,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
             {
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -784,7 +784,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -794,7 +794,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -805,7 +805,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -816,7 +816,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment() == "new comment");
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -827,7 +827,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -837,7 +837,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment() == "new comment");
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -848,7 +848,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -869,7 +869,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -880,7 +880,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -890,7 +890,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -901,7 +901,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -919,7 +919,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -930,7 +930,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -940,7 +940,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -951,7 +951,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -969,7 +969,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE_FALSE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -980,7 +980,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE_FALSE(de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE_FALSE(de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -991,7 +991,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE_FALSE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -1002,7 +1002,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE_FALSE(clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE_FALSE(clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_stats.st_size) + " bytes)");
@@ -1023,7 +1023,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                         REQUIRE(de.getComment().empty());
                         REQUIRE(de.getCompressedSize() == file_size);
-                        REQUIRE(de.getCrc() == 0);
+                        REQUIRE(de.getCrc() != 0);
                         REQUIRE(de.getEntryOffset() == 0);
                         REQUIRE(de.getExtra().empty());
                         REQUIRE(de.getHeaderSize() == 0);
@@ -1034,7 +1034,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                         REQUIRE(de.getSize() == file_size);
                         REQUIRE(de.getTime() == dt.getDOSDateTime());
                         REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                        REQUIRE_FALSE(de.hasCrc());
+                        REQUIRE(de.hasCrc());
                         REQUIRE_FALSE(de.isDirectory());
                         REQUIRE(de.isValid());
                         REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -1055,7 +1055,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -1066,7 +1066,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE_FALSE(de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE_FALSE(de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -1076,7 +1076,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -1087,7 +1087,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE_FALSE(clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE_FALSE(clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -1105,7 +1105,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == r);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -1116,7 +1116,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == r);
                 REQUIRE(de.getTime() == dt.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(r) + " bytes)");
@@ -1126,7 +1126,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == r);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -1137,7 +1137,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == r);
                 REQUIRE(clone->getTime() == dt.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == file_stats.st_mtime);
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(r) + " bytes)");
@@ -1161,7 +1161,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -1172,7 +1172,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == r.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == r.getUnixTimestamp()); // WARNING: this is not always equal to t because setTime() may use the next even second
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -1182,7 +1182,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -1193,7 +1193,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == r.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == r.getUnixTimestamp());
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -1209,7 +1209,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(de.getComment().empty());
                 REQUIRE(de.getCompressedSize() == file_size);
-                REQUIRE(de.getCrc() == 0);
+                REQUIRE(de.getCrc() != 0);
                 REQUIRE(de.getEntryOffset() == 0);
                 REQUIRE(de.getExtra().empty());
                 REQUIRE(de.getHeaderSize() == 0);
@@ -1220,7 +1220,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(de.getSize() == file_size);
                 REQUIRE(de.getTime() == dr.getDOSDateTime());
                 REQUIRE(de.getUnixTime() == r);
-                REQUIRE(!de.hasCrc());
+                REQUIRE(de.hasCrc());
                 REQUIRE(!de.isDirectory());
                 REQUIRE(de.isValid());
                 REQUIRE(de.toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");
@@ -1230,7 +1230,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
 
                 REQUIRE(clone->getComment().empty());
                 REQUIRE(clone->getCompressedSize() == file_size);
-                REQUIRE(clone->getCrc() == 0);
+                REQUIRE(clone->getCrc() != 0);
                 REQUIRE(clone->getEntryOffset() == 0);
                 REQUIRE(clone->getExtra().empty());
                 REQUIRE(clone->getHeaderSize() == 0);
@@ -1241,7 +1241,7 @@ TEST_CASE("DirectoryEntry with one valid file", "[DirectoryEntry] [FileEntry]")
                 REQUIRE(clone->getSize() == file_size);
                 REQUIRE(clone->getTime() == dr.getDOSDateTime());
                 REQUIRE(clone->getUnixTime() == r);
-                REQUIRE(!clone->hasCrc());
+                REQUIRE(clone->hasCrc());
                 REQUIRE(!clone->isDirectory());
                 REQUIRE(clone->isValid());
                 REQUIRE(clone->toString() == "filepath-test.txt (" + std::to_string(file_size) + " bytes)");

--- a/tests/zipfile.cpp
+++ b/tests/zipfile.cpp
@@ -965,6 +965,27 @@ TEST_CASE("Simple Valid and Invalid ZipFile Archives", "[ZipFile] [FileCollectio
     }
 }
 
+#ifdef __unix__
+TEST_CASE("Check saveCollectionToArchive with DirectoryCollection")
+{
+    REQUIRE(system("mkdir -p test_dir") == 0);
+
+    {
+        std::ofstream file_bin("test_dir/file1.bin", std::ios::out | std::ios::binary);
+        for(int pos(0); pos < 1024; ++pos)
+        {
+            file_bin << static_cast<char>(rand());
+        }
+    }
+
+    zipios::DirectoryCollection directoryCollection("test_dir");
+    std::ofstream tempZipStream("test.zip", std::ios_base::binary | std::ios::out);
+    zipios::ZipFile::saveCollectionToArchive(tempZipStream, directoryCollection);
+    tempZipStream.close();
+
+    REQUIRE(system("unzip -o test.zip") == 0);
+}
+#endif
 
 // For this one we have a set of structures and we "manually"
 // create Zip archive files that we can thus tweak with totally

--- a/zipios/directoryentry.hpp
+++ b/zipios/directoryentry.hpp
@@ -47,6 +47,9 @@ public:
     virtual                 ~DirectoryEntry() override;
 
     virtual bool            isEqual(FileEntry const & file_entry) const override;
+
+private:
+    void computeCRC32();
 };
 
 


### PR DESCRIPTION
This is my attempt to fix the #38 issue.

I've identified two problems:

- DirectoryEntry on a file has no crc32, hence I've added the crc32 computation in the constructor
- DirectoryEntry is not "compressed" so ZipOutputStreambuf::overflow is not called and ZipOutputStreambuf::updateEntryHeaderInfo push a 0 crc32. The fix is to check that the crc32 has been computed before assigning it.

Tests has been updated to check that the crc32 is computed when directoryEntry represents a file.

I've also added a specific test for this issue. The test is protected by the   `#ifdef __unix__` guard because it calls some unix command line utilities.

Fell free to modify, update and discuss !

