### PR TITLE
appendzip example: uint32_t is not in std namespace.

### DIFF
--- a/tools/appendzip.cpp
+++ b/tools/appendzip.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     }
 
     // get eof pos (to become zip file starting position).
-    std::uint32_t const zip_start(exef.tellp());
+    uint32_t const zip_start(exef.tellp());
     std::cout << "zip starts at " << zip_start << std::endl;
 
     // Append zip file to exe file


### PR DESCRIPTION
On Fedora 38 with gcc-c++ 13.1.1-4, the appendzip example fails to compile, because uint32_t is not in the std namespace. Removing the std:: namespace prefix fixes the problem.